### PR TITLE
feat: MCP 컨텍스트 메시지 스키마 정의 및 Redis 연동

### DIFF
--- a/src/main/java/MuskElion/CodeGraph/CodeGraphApplication.java
+++ b/src/main/java/MuskElion/CodeGraph/CodeGraphApplication.java
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
 
-@SpringBootApplication(exclude = {RedisAutoConfiguration.class, RedisRepositoriesAutoConfiguration.class})
+@SpringBootApplication
 public class CodeGraphApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/MuskElion/CodeGraph/mcp/McpContextMessage.java
+++ b/src/main/java/MuskElion/CodeGraph/mcp/McpContextMessage.java
@@ -1,0 +1,16 @@
+package MuskElion.CodeGraph.mcp;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class McpContextMessage {
+    private String eventType;
+    private String sourceModel;
+    private String targetModel;
+    private String payload;
+    private long timestamp;
+}

--- a/src/main/java/MuskElion/CodeGraph/mcp/config/RedisConfig.java
+++ b/src/main/java/MuskElion/CodeGraph/mcp/config/RedisConfig.java
@@ -1,0 +1,51 @@
+package MuskElion.CodeGraph.mcp.config;
+
+import MuskElion.CodeGraph.mcp.service.McpSubscribeService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    // MCP 메시지를 구독할 채널(토픽) 정의
+    @Bean
+    public ChannelTopic mcpTopic() {
+        return new ChannelTopic("mcp-channel");
+    }
+
+    // Redis 메시지 리스너 컨테이너 설정
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(
+            RedisConnectionFactory connectionFactory,
+            MessageListenerAdapter listenerAdapter,
+            ChannelTopic mcpTopic) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        container.addMessageListener(listenerAdapter, mcpTopic);
+        return container;
+    }
+
+    // 메시지를 수신하고 처리할 구독 서비스(McpSubscribeService)를 리스너로 등록
+    @Bean
+    public MessageListenerAdapter listenerAdapter(McpSubscribeService subscriber) {
+        return new MessageListenerAdapter(subscriber, "onMessage");
+    }
+
+    // Redis에 데이터를 쓰고 읽는 데 사용할 RedisTemplate 설정
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        // McpContextMessage DTO를 JSON 형태로 직렬화/역직렬화
+        template.setValueSerializer(new Jackson2JsonRedisSerializer<>(Object.class));
+        return template;
+    }
+}

--- a/src/main/java/MuskElion/CodeGraph/mcp/controller/McpController.java
+++ b/src/main/java/MuskElion/CodeGraph/mcp/controller/McpController.java
@@ -1,0 +1,28 @@
+package MuskElion.CodeGraph.mcp.controller;
+
+import MuskElion.CodeGraph.mcp.McpContextMessage;
+import MuskElion.CodeGraph.mcp.service.McpPublishService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/mcp")
+@RequiredArgsConstructor
+public class McpController {
+
+    private final McpPublishService publishService;
+
+    @Operation(
+            summary = "MCP 메시지 발행 테스트",
+            description = "테스트용 MCP 메시지를 Redis 채널로 발행합니다."
+    )
+    @PostMapping("/publish")
+    public String publishMessage(@RequestBody McpContextMessage message) {
+        publishService.publish(message);
+        return "Message published successfully to mcp-channel";
+    }
+}

--- a/src/main/java/MuskElion/CodeGraph/mcp/service/McpPublishService.java
+++ b/src/main/java/MuskElion/CodeGraph/mcp/service/McpPublishService.java
@@ -1,0 +1,23 @@
+package MuskElion.CodeGraph.mcp.service;
+
+import MuskElion.CodeGraph.mcp.McpContextMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class McpPublishService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ChannelTopic mcpTopic;
+
+    /**
+     * MCP 컨텍스트 메시지를 Redis 채널로 발행합니다.
+     * @param message 발행할 메시지 객체
+     */
+    public void publish(McpContextMessage message) {
+        redisTemplate.convertAndSend(mcpTopic.getTopic(), message);
+    }
+}

--- a/src/main/java/MuskElion/CodeGraph/mcp/service/McpSubscribeService.java
+++ b/src/main/java/MuskElion/CodeGraph/mcp/service/McpSubscribeService.java
@@ -1,0 +1,27 @@
+package MuskElion.CodeGraph.mcp.service;
+
+import MuskElion.CodeGraph.mcp.McpContextMessage;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class McpSubscribeService {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * Redis 채널로부터 메시지를 수신했을 때 호출되는 메서드.
+     * @param message 수신된 메시지 (JSON 문자열)
+     */
+    public void onMessage(String message) {
+        try {
+            McpContextMessage contextMessage = objectMapper.readValue(message, McpContextMessage.class);
+            log.info("Received MCP message: {}", contextMessage);
+            // TODO: 수신된 메시지를 기반으로 실제 비즈니스 로직 처리
+        } catch (Exception e) {
+            log.error("Failed to parse MCP message: {}", message, e);
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,7 +6,7 @@ spring.neo4j.authentication.username=${NEO4J_USERNAME}
 spring.neo4j.authentication.password=${NEO4J_PASSWORD}
 
 # Redis Connection Settings
-spring.data.redis.host=my-cache-server
+spring.data.redis.host=${REDIS_HOST}
 spring.data.redis.port=6379
 
 # OpenAI Gemini API Settings


### PR DESCRIPTION
## 🔍 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. (예: #123) -->
- Closes #6

## 📝 작업 내용
<!-- 작업한 내용을 간략하게 설명해주세요. -->
- `McpContextMessage.java` DTO 정의: 모델 간 컨텍스트 공유를 위한 JSON 스키마를 반영하여 McpContextMessage DTO를 정의했습니다.
- Redis 연결 정보 설정 및 확인: application.properties의 Redis 연결 정보를 확인하고, 애플리케이션이 Redis 서버에 정상적으로 연결되도록 관련 설정을 완료했습니다.
- Spring Data Redis 의존성 확인: build.gradle에 spring-boot-starter-data-redis 의존성이 올바르게 포함되어 있음을 확인했습니다
- RedisConfig를 통해 메시지 발행/구독에 필요한 빈(Bean)을 설정했습니다.
- McpPublishService (발행)와 McpSubscribeService (구독)를 구현하여 실제 메시징 로직을 개발했습니다.
- /api/mcp/publish 테스트 엔드포인트를 포함하는 McpController를 추가하여 전체 Pub/Sub 기능의 동작을 검증할 수 있도록 구현을 완료했습니다.
