### PR TITLE
그래프 데이터 변경 시 MCP 이벤트 발행 기능 구현

### DIFF
--- a/src/test/java/MuskElion/CodeGraph/graph/service/McpPublishServiceStub.java
+++ b/src/test/java/MuskElion/CodeGraph/graph/service/McpPublishServiceStub.java
@@ -1,0 +1,26 @@
+package MuskElion.CodeGraph.graph.service;
+
+import MuskElion.CodeGraph.mcp.McpContextMessage;
+import MuskElion.CodeGraph.mcp.service.McpPublishService;
+
+/**
+ * McpPublishService의 테스트 스텁.
+ */
+public class McpPublishServiceStub extends McpPublishService {
+
+    public boolean publishCalled = false;
+    public McpContextMessage lastPublishedMessage = null;
+
+    public McpPublishServiceStub() {
+        // RedisTemplate과 ChannelTopic은 부모 생성자에서 필요하지만, 스텁에서는 사용하지 않으므로 null 전달
+        // 실제 테스트에서는 이 스텁이 RedisTemplate과 ChannelTopic을 사용하지 않음을 보장해야 함
+        super(null, null);
+    }
+
+    @Override
+    public void publish(McpContextMessage message) {
+        this.publishCalled = true;
+        this.lastPublishedMessage = message;
+        System.out.println("McpPublishServiceStub: Message published: " + message);
+    }
+}


### PR DESCRIPTION
## 🔍 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. (예: #123) -->
- Closes #25 

## 📝 작업 내용
<!-- 작업한 내용을 간략하게 설명해주세요. -->
 - **`GraphServiceImpl` 수정**: `McpPublishService`를 주입받도록 변경하고, `saveParsedResult` 메서드에서 그래프 저장이 완료되거나 실패할 때 `GRAPH_UPDATED` MCP 이벤트를 발행하도록 로직을 추가.
- **MCP 메시지 내용 정의**: 발행되는 `McpContextMessage`의 `payload`에 변경된 파일 경로(`filePath`)와 처리 상태(`status`)를 포함하도록 구현.
- **테스트 코드 업데이트**: `GraphServiceTest`를 수정하여 `GraphServiceImpl`의 변경된 생성자에 맞춰 스텁을 주입하고, 발행된 MCP 메시지의 내용을 정확하게 검증하는 테스트 로직을 추가.

## 📸 스크린샷 또는 동영상
<!-- 결과물을 확인할 수 있는 스크린샷이나 동영상을 첨부해주세요. -->

## ✔️ 테스트 방법
<!-- PR 내용을 테스트할 수 있는 방법을 구체적으로 설명해주세요. -->
- 

## 💬 기타 사항
<!-- 리뷰어에게 전달하고 싶은 내용이나 기타 참고 사항을 적어주세요. -->
